### PR TITLE
fix: return correct file name based on input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Thumbs.db
 coverage/
 .nyc_output/
 *.lcov
+
+# Version manager files
+.tool-versions

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -60,6 +60,24 @@ export class AudioService {
     return player
   }
 
+  getBestMatchingAudio(completeOrPartiaAudioName: string): string {
+    const audioFiles = fs.readdirSync(this.audiosPath)
+      .map((file): AudioFileInfo => {
+        const bootstrap = file.includes(completeOrPartiaAudioName) ? 100 : 0
+        const metric = bootstrap + stringSimilarity(completeOrPartiaAudioName, file.replace(/\D/, ''))
+        return { file, distance: metric }
+      })
+      .sort((o1, o2) => o2.distance - o1.distance)
+
+    const bestMatch = audioFiles[0]
+    if (!bestMatch) {
+      console.error('❌ Nenhum áudio encontrado')
+      return '';
+    }
+
+    return bestMatch.file;
+  }
+
   /**
    * Toca um áudio específico pelo nome
    */
@@ -68,22 +86,12 @@ export class AudioService {
     connection: VoiceConnection,
     timeLimitMs: number = 5000
   ): void {
-    const audioFiles = fs.readdirSync(this.audiosPath)
-      .map((file): AudioFileInfo => {
-        const bootstrap = file.includes(audioName) ? 100 : 0
-        const metric = bootstrap + stringSimilarity(audioName, file.replace(/\D/, ''))
-        return { file, distance: metric }
-      })
-      .sort((o1, o2) => o2.distance - o1.distance)
-
-    const bestMatch = audioFiles[0]
-    if (!bestMatch) {
-      console.error('❌ Nenhum áudio encontrado')
+    if (!audioName) {
       return
     }
 
-    const audioFilePath = join(this.audiosPath, bestMatch.file)
-    console.log(`🎵 Tocando áudio: ${bestMatch.file}`)
+    const audioFilePath = join(this.audiosPath, audioName)
+    console.log(`🎵 Tocando áudio: ${audioName}`)
     this.createPlayerWithTimeLimit(audioFilePath, connection, timeLimitMs)
   }
 

--- a/src/services/CommandService.ts
+++ b/src/services/CommandService.ts
@@ -52,7 +52,7 @@ export class CommandService {
       console.log(`⏭️  Nenhum áudio encontrado para sua busca`)
     }
 
-    await message.reply(`🔊 Tocando "${audioFileName}.mp3" no servidor: ${guildName}`)
+    await message.reply(`🔊 Tocando "${audioFileName}" no servidor: ${guildName}`)
 
     this.voiceService.playAudioByName(audioFileName, connection)
   }

--- a/src/services/CommandService.ts
+++ b/src/services/CommandService.ts
@@ -46,9 +46,15 @@ export class CommandService {
       return
     }
 
-    await message.reply(`🔊 Tocando "${audioName}.mp3" no servidor: ${guildName}`)
+    const audioFileName = this.voiceService.getBestMatchingAudio(audioName)
 
-    this.voiceService.playAudioByName(audioName, connection)
+    if (!audioFileName) {
+      console.log(`⏭️  Nenhum áudio encontrado para sua busca`)
+    }
+
+    await message.reply(`🔊 Tocando "${audioFileName}.mp3" no servidor: ${guildName}`)
+
+    this.voiceService.playAudioByName(audioFileName, connection)
   }
 
   /**

--- a/src/services/CommandService.ts
+++ b/src/services/CommandService.ts
@@ -48,7 +48,7 @@ export class CommandService {
 
     const audioFileName = this.voiceService.getBestMatchingAudio(audioName)
 
-    if (!audioFileName) {
+    if (audioFileName.length === 0) {
       console.log(`⏭️  Nenhum áudio encontrado para sua busca`)
     }
 

--- a/src/services/VoiceService.ts
+++ b/src/services/VoiceService.ts
@@ -187,6 +187,13 @@ export class VoiceService {
   }
 
   /**
+   * Dado uma string completa ou parcial, busca o melhor nome de áudio correspondente
+   */
+  getBestMatchingAudio(audioName: string): string {
+    return this.audioService.getBestMatchingAudio(audioName)
+  }
+
+  /**
    * Encontra o canal "Casinha do Xeréu" em um servidor
    */
   private findCasinhaChannel(guild: Guild): VoiceChannel | null {


### PR DESCRIPTION
corrige a mensagem "tocando {audio}.mp3" para o nome correto do arquivo em vez o nome que foi passado na mensagem.

<img width="352" height="56" alt="image" src="https://github.com/user-attachments/assets/5eecb164-8d0a-48c6-a4fe-b4f99324da09" />

no caso da imagem o nome do arquivo de audio não é `romance`. `romance` é apenas o input do usuário que foi utilizado para escolher o nome de arquivo mais próximo, nome correto do arquivo seria `romanceeeeeeeeeeeeee` 