### PR TITLE
fix: opus fallback, redis shutdown, duração de áudio parametrizável e correções de coleira/afinidade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "ffmpeg-static": "^5.3.0",
         "ioredis": "^5.4.1",
         "openai": "^4.77.0",
+        "opusscript": "^0.0.8",
         "pino": "^9.5.0",
         "pino-pretty": "^11.3.0",
         "sodium-native": "^5.0.10",
@@ -4140,7 +4141,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6021,6 +6021,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/opusscript": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
+      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,13 @@
     "docker:down": "docker compose down",
     "docker:logs": "docker compose logs -f"
   },
-  "keywords": ["discord", "bot", "pet", "openai", "ai"],
+  "keywords": [
+    "discord",
+    "bot",
+    "pet",
+    "openai",
+    "ai"
+  ],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
@@ -38,6 +44,7 @@
     "ffmpeg-static": "^5.3.0",
     "ioredis": "^5.4.1",
     "openai": "^4.77.0",
+    "opusscript": "^0.0.8",
     "pino": "^9.5.0",
     "pino-pretty": "^11.3.0",
     "sodium-native": "^5.0.10",

--- a/src/commands/PlayCommand.ts
+++ b/src/commands/PlayCommand.ts
@@ -20,6 +20,14 @@ export class PlayCommand implements XareuCommand {
     .addStringOption((opt) =>
       opt.setName('audio').setDescription('Nome (ou parte) do áudio').setRequired(true).setAutocomplete(true),
     )
+    .addIntegerOption((opt) =>
+      opt
+        .setName('duracao')
+        .setDescription('Duração em segundos (padrão: 5)')
+        .setRequired(false)
+        .setMinValue(1)
+        .setMaxValue(60),
+    )
 
   constructor(
     private readonly audioService: AudioService,
@@ -57,6 +65,7 @@ export class PlayCommand implements XareuCommand {
       return
     }
     const query = interaction.options.getString('audio', true)
+    const durationSeconds = interaction.options.getInteger('duracao') ?? undefined
     const connection = this.voiceService.getConnection(interaction.guildId)
     if (!connection) {
       await interaction.reply({
@@ -82,6 +91,7 @@ export class PlayCommand implements XareuCommand {
       fileName: match.fileName,
       cooldownSeconds: config.audioCooldown,
       volume: config.volume,
+      durationSeconds,
       connection,
     })
 

--- a/src/handlers/VoiceStateHandler.ts
+++ b/src/handlers/VoiceStateHandler.ts
@@ -113,7 +113,6 @@ export class VoiceStateHandler {
       if (config.leashOwnerId && this.voiceService.isFollowing(guildId)) {
         const owner = await this.intelligence.getOrCreateUser({
           discordId: config.leashOwnerId,
-          username: config.leashOwnerId,
         })
         if (owner.affinity < AFFINITY_CONFIG.LEASH_MIN) {
           logger.info(
@@ -134,13 +133,13 @@ export class VoiceStateHandler {
         return
       }
 
-      // Coleira: se há dono definido e o usuário não é o dono → ignora
+      // Coleira: se há dono definido e o usuário não é o dono → ignora.
+      // Bot fica com o dono, não segue quem não tem coleira.
       if (config.leashOwnerId && userId !== config.leashOwnerId) {
-        const following = this.voiceService.isFollowing(guildId)
-        logger.info({ userId, owner: config.leashOwnerId, following }, '🎀 branch: não-dono moveu')
-        if (following) {
-          await this.voiceService.handleChannelEntry(newChannel)
-        }
+        logger.info(
+          { userId, owner: config.leashOwnerId, following: this.voiceService.isFollowing(guildId) },
+          '🎀 branch: não-dono moveu — bot ignora',
+        )
         return
       }
 

--- a/src/infrastructure/redis.ts
+++ b/src/infrastructure/redis.ts
@@ -18,6 +18,7 @@ export function getRedis(): Redis {
 
 export async function disconnectRedis(): Promise<void> {
   if (client) {
+    client.removeAllListeners('error')
     await client.quit()
     client = null
   }

--- a/src/repositories/UserRepository.ts
+++ b/src/repositories/UserRepository.ts
@@ -4,7 +4,7 @@ import { clamp } from '../utils/helpers'
 
 export interface UpsertUserInput {
   discordId: string
-  username: string
+  username?: string
   displayName?: string | null
 }
 
@@ -12,17 +12,18 @@ export class UserRepository {
   constructor(private readonly prisma: PrismaClient) {}
 
   async upsertByDiscordId(input: UpsertUserInput): Promise<User> {
+    const update: { username?: string; displayName?: string } = {}
+    if (input.username && input.username !== input.discordId) update.username = input.username
+    if (input.displayName) update.displayName = input.displayName
+
     return this.prisma.user.upsert({
       where: { discordId: input.discordId },
       create: {
         discordId: input.discordId,
-        username: input.username,
+        username: input.username ?? input.discordId,
         displayName: input.displayName ?? null,
       },
-      update: {
-        username: input.username,
-        displayName: input.displayName ?? null,
-      },
+      update,
     })
   }
 
@@ -31,7 +32,7 @@ export class UserRepository {
   }
 
   async updateAffinity(discordId: string, delta: number): Promise<User> {
-    const user = await this.upsertByDiscordId({ discordId, username: discordId })
+    const user = await this.upsertByDiscordId({ discordId })
     const affinity = clamp(user.affinity + delta, AFFINITY_CONFIG.MIN, AFFINITY_CONFIG.MAX)
     return this.prisma.user.update({
       where: { id: user.id },

--- a/src/services/AudioQueueService.ts
+++ b/src/services/AudioQueueService.ts
@@ -1,13 +1,12 @@
 import { VoiceConnection } from '@discordjs/voice'
 import { AudioService } from './AudioService'
 import { logger } from '../utils/logger'
-import { BOT_CONFIG } from '../config/constants'
 
 interface QueueItem {
   fileName: string
   guildId: string
   volume: number
-  timeLimitMs: number
+  timeLimitMs?: number
 }
 
 /**
@@ -54,7 +53,7 @@ export class AudioQueueService {
     const timeLimitMs =
       args.durationSeconds && args.durationSeconds > 0
         ? args.durationSeconds * 1000
-        : BOT_CONFIG.AUDIO_TIME_LIMIT_MS
+        : undefined
     const queue = this.queues.get(args.guildId) ?? []
     queue.push({
       fileName: args.fileName,
@@ -80,7 +79,7 @@ export class AudioQueueService {
     volume = 1.0,
   ): Promise<void> {
     const queue = this.queues.get(guildId) ?? []
-    queue.push({ fileName, guildId, volume, timeLimitMs: BOT_CONFIG.AUDIO_TIME_LIMIT_MS })
+    queue.push({ fileName, guildId, volume })
     this.queues.set(guildId, queue)
     logger.debug({ guildId, fileName, queueSize: queue.length }, '📥 playInternal enfileirou')
     await this.drain(guildId, connection)

--- a/src/services/AudioQueueService.ts
+++ b/src/services/AudioQueueService.ts
@@ -7,6 +7,7 @@ interface QueueItem {
   fileName: string
   guildId: string
   volume: number
+  timeLimitMs: number
 }
 
 /**
@@ -29,6 +30,7 @@ export class AudioQueueService {
     fileName: string
     cooldownSeconds: number
     volume?: number
+    durationSeconds?: number
     connection: VoiceConnection
   }): { ok: boolean; cooldownRemaining?: number } {
     const cooldownMs = args.cooldownSeconds * 1000
@@ -49,8 +51,17 @@ export class AudioQueueService {
       this.userCooldownExpiresAt.set(cooldownKey, now + cooldownMs)
     }
 
+    const timeLimitMs =
+      args.durationSeconds && args.durationSeconds > 0
+        ? args.durationSeconds * 1000
+        : BOT_CONFIG.AUDIO_TIME_LIMIT_MS
     const queue = this.queues.get(args.guildId) ?? []
-    queue.push({ fileName: args.fileName, guildId: args.guildId, volume: args.volume ?? 1.0 })
+    queue.push({
+      fileName: args.fileName,
+      guildId: args.guildId,
+      volume: args.volume ?? 1.0,
+      timeLimitMs,
+    })
     this.queues.set(args.guildId, queue)
     logger.info(
       { guildId: args.guildId, userId: args.userId, fileName: args.fileName, queueSize: queue.length },
@@ -69,7 +80,7 @@ export class AudioQueueService {
     volume = 1.0,
   ): Promise<void> {
     const queue = this.queues.get(guildId) ?? []
-    queue.push({ fileName, guildId, volume })
+    queue.push({ fileName, guildId, volume, timeLimitMs: BOT_CONFIG.AUDIO_TIME_LIMIT_MS })
     this.queues.set(guildId, queue)
     logger.debug({ guildId, fileName, queueSize: queue.length }, '📥 playInternal enfileirou')
     await this.drain(guildId, connection)
@@ -101,7 +112,7 @@ export class AudioQueueService {
           await this.audioService.playFile(
             connection,
             next.fileName,
-            BOT_CONFIG.AUDIO_TIME_LIMIT_MS,
+            next.timeLimitMs,
             next.volume,
           )
         } catch (err) {

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -84,7 +84,7 @@ export class AudioService {
   async playFile(
     connection: VoiceConnection,
     fileName: string,
-    timeLimitMs: number,
+    timeLimitMs?: number,
     volume = 1.0,
   ): Promise<void> {
     const audioPath = join(this.audiosPath, fileName)
@@ -98,8 +98,10 @@ export class AudioService {
       const resource = createAudioResource(audioPath, { inlineVolume: true })
       resource.volume?.setVolume(volume)
 
+      let stopTimer: ReturnType<typeof setTimeout> | undefined
+
       const cleanup = (): void => {
-        clearTimeout(stopTimer)
+        if (stopTimer !== undefined) clearTimeout(stopTimer)
         player.removeAllListeners()
         try {
           player.stop()
@@ -108,13 +110,15 @@ export class AudioService {
         }
       }
 
-      const stopTimer = setTimeout(() => {
-        if (player.state.status !== AudioPlayerStatus.Idle) {
-          logger.debug({ fileName, timeLimitMs }, 'Áudio interrompido por limite de tempo')
-        }
-        cleanup()
-        resolvePromise()
-      }, timeLimitMs)
+      if (timeLimitMs !== undefined && timeLimitMs > 0) {
+        stopTimer = setTimeout(() => {
+          if (player.state.status !== AudioPlayerStatus.Idle) {
+            logger.debug({ fileName, timeLimitMs }, 'Áudio interrompido por limite de tempo')
+          }
+          cleanup()
+          resolvePromise()
+        }, timeLimitMs)
+      }
 
       player.on(AudioPlayerStatus.Idle, () => {
         cleanup()

--- a/src/services/IntelligenceService.ts
+++ b/src/services/IntelligenceService.ts
@@ -37,7 +37,7 @@ export class IntelligenceService {
   /** Garante que o usuário existe e aplica decaimento de afinidade pelo tempo passado. */
   async getOrCreateUser(input: {
     discordId: string
-    username: string
+    username?: string
     displayName?: string | null
   }): Promise<User> {
     const existing = await this.userRepo.findByDiscordId(input.discordId)

--- a/src/services/VoiceService.ts
+++ b/src/services/VoiceService.ts
@@ -293,8 +293,8 @@ export class VoiceService {
 
   /**
    * Reação do bot quando alguém entra no canal onde ele já está:
-   * - afinidade < 30 → rosnado (alto)
-   * - afinidade ≥ 30 (ou sem memória) → latido amigável de cumprimento
+   * - desconhecido (sem memória) ou afinidade < 30 → rosnado (alto)
+   * - afinidade ≥ 30 → latido amigável de cumprimento
    */
   async playEntryReactionFor(guildId: string, userId: string): Promise<void> {
     const connection = getVoiceConnection(guildId)
@@ -304,10 +304,10 @@ export class VoiceService {
     const threshold = AFFINITY_CONFIG.ROSNADO_AFFINITY_MAX
     const affinity = memory?.user.affinity
 
-    if (affinity !== undefined && affinity < threshold) {
+    if (affinity === undefined || affinity < threshold) {
       log.info(
         { guildId, userId, affinity, threshold },
-        '🐺 rosnando: user de afinidade baixa entrou no canal do bot',
+        '🐺 rosnando: desconhecido ou afinidade baixa entrou no canal do bot',
       )
       void this.audioQueue.playInternal(
         connection,


### PR DESCRIPTION
## Resumo

Correções de bugs encontrados ao rodar o bot localmente, além de uma nova opção de duração no comando `/play`.

- **Opus (voz)**: adiciona `opusscript` como fallback puro-JS para quando o binário nativo do `@discordjs/opus` não é compatível com a versão do Node em uso, corrigindo falha ao reproduzir áudio.
- **Redis (shutdown)**: remove os listeners de erro antes de chamar `client.quit()`, evitando logs de `ECONNREFUSED` durante o encerramento gracioso do bot.
- **Duração de áudio no `/play`**: adiciona opção `duracao` (1–60s). Se informada, o áudio é interrompido nesse tempo; se omitida, toca até o fim natural do arquivo (antes sempre limitava a 5s por padrão).
- **Coleira — não seguir não-dono**: corrige comportamento para o bot ignorar completamente usuários que não são o dono quando há coleira ativa — antes ele podia seguir um não-dono se já estivesse em modo "following".
- **Coleira — upsert do dono**: remove o `username` fixo (igual ao `discordId`) passado ao buscar/criar o registro do dono, aproveitando o novo campo opcional para não sobrescrever o nome real já salvo.
- **UserRepository/IntelligenceService**: `username` passa a ser opcional no upsert; atualizações de afinidade não sobrescrevem mais o `displayName`/`username` do usuário com o Discord ID.
- **Reação de entrada no canal**: usuários desconhecidos (sem registro de afinidade) agora recebem rosnado em vez de latido amigável, alinhado com usuários de afinidade baixa.

## Test plan

- [x] `npm run dev` sobe sem erros de Redis/Opus
- [x] `/play <audio>` sem `duracao` toca o áudio inteiro
- [x] `/play <audio> duracao:3` interrompe em 3s
- [x] `npx tsc --noEmit` sem erros
- [ ] Validar manualmente comportamento da coleira com múltiplos usuários no canal
